### PR TITLE
WIP: PBFT Dynamic Network

### DIFF
--- a/protos/pbft_message.proto
+++ b/protos/pbft_message.proto
@@ -25,6 +25,8 @@ message PbftBlock {
   uint64 block_num = 3;
 
   bytes summary = 4;
+
+  bytes previous_id = 5;
 }
 
 // Represents all common information used in a PBFT message
@@ -62,3 +64,21 @@ message PbftViewChange {
   // checkpoint mentioned in info's `sequence_number`
   repeated PbftMessage checkpoint_messages = 2;
 }
+
+// Represents the current state of the network, including the active nodes,
+// and the current block.
+message PbftNetworkChange {
+  // The peers in this network configuration
+  repeated bytes peers = 1;
+
+  // The current block that the network is on - used to help nodes catch back
+  // up to the current chain head after they've been offline
+  PbftBlock head = 2;
+
+  // Does this message represent a tentative configuration, or a final
+  // configuration?
+  bool tentative = 3;
+
+  bytes signer_id = 4;
+}
+

--- a/protos/pbft_message.proto
+++ b/protos/pbft_message.proto
@@ -80,5 +80,6 @@ message PbftNetworkChange {
   bool tentative = 3;
 
   bytes signer_id = 4;
-}
 
+  PbftMessageInfo info = 5;
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,7 +59,7 @@ impl PbftConfig {
             peers: Vec::new(),
             block_duration: Duration::from_millis(200),
             message_timeout: Duration::from_millis(10),
-            view_change_timeout: Duration::from_millis(4000),
+            view_change_timeout: Duration::from_secs(30),
             checkpoint_period: 100,
             max_log_size: 1000,
         }
@@ -126,7 +126,7 @@ pub fn load_pbft_config(block_id: BlockId, service: &mut Box<Service>) -> PbftCo
     }
     if let Some(s) = sawtooth_settings.get("sawtooth.consensus.pbft.view_change_timeout") {
         if let Ok(view_change_timeout) = s.parse() {
-            config.view_change_timeout = Duration::from_millis(view_change_timeout);
+            config.view_change_timeout = Duration::from_secs(view_change_timeout);
         }
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -19,6 +19,8 @@
 
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
 
+use hex;
+
 use sawtooth_sdk::consensus::{engine::*, service::Service};
 
 use node::PbftNode;
@@ -45,24 +47,33 @@ impl Engine for PbftEngine {
     ) {
         let StartupState {
             chain_head,
-            peers: _peers,
-            local_peer_info,
+            peers,
+            local_peer_info
         } = startup_state;
+
+        let mut deduped_peers = vec![];
+        for peer_info in peers.into_iter() {
+            if !deduped_peers.contains(&peer_info.peer_id) {
+                deduped_peers.push(peer_info.peer_id);
+            }
+        }
+
+        info!(
+            "Starting node {} with peers: {:#?}",
+            &hex::encode(&local_peer_info.peer_id)[..6],
+            deduped_peers
+        );
 
         // Load on-chain settings
         let config = config::load_pbft_config(chain_head.block_id, &mut service);
 
-        let node_id = config
-            .peers
-            .iter()
-            .position(|ref id| id == &&local_peer_info.peer_id)
-            .expect("This node is not in the peers list, which is necessary")
-            as u64;
+        let tmp_node_id = deduped_peers.len() as u64;
+        deduped_peers.push(local_peer_info.peer_id);
 
         let mut working_ticker = timing::Ticker::new(config.block_duration);
         let mut backlog_ticker = timing::Ticker::new(config.message_timeout);
 
-        let mut node = PbftNode::new(node_id, &config, service);
+        let mut node = PbftNode::new(tmp_node_id, &config, deduped_peers, service);
 
         debug!("Starting state: {:#?}", node.state);
 
@@ -82,11 +93,11 @@ impl Engine for PbftEngine {
                 }
                 Ok(Update::BlockCommit(block_id)) => node.on_block_commit(block_id),
                 Ok(Update::PeerMessage(message, _sender_id)) => node.on_peer_message(message),
-                Ok(Update::Shutdown) => break,
-                Ok(Update::PeerConnected(_)) | Ok(Update::PeerDisconnected(_)) => {
-                    error!("PBFT currently only supports static networks");
-                    Ok(())
+                Ok(Update::PeerConnected(peer_info)) => {
+                    node.on_peer_change(peer_info.peer_id, true)
                 }
+                Ok(Update::PeerDisconnected(peer_id)) => node.on_peer_change(peer_id, false),
+                Ok(Update::Shutdown) => break,
                 Err(RecvTimeoutError::Timeout) => Err(PbftError::Timeout),
                 Err(RecvTimeoutError::Disconnected) => {
                     error!("Disconnected from validator");

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -343,7 +343,7 @@ pub fn view_change(
 }
 
 // There should only be one block with a matching ID
-fn get_block_by_id(service: &mut Box<Service>, block_id: BlockId) -> Option<Block> {
+pub fn get_block_by_id(service: &mut Box<Service>, block_id: BlockId) -> Option<Block> {
     let blocks: Vec<Block> = service
         .get_blocks(vec![block_id.clone()])
         .unwrap_or(HashMap::new())

--- a/src/message_extensions.rs
+++ b/src/message_extensions.rs
@@ -23,7 +23,7 @@
 
 use std::hash::{Hash, Hasher};
 
-use protos::pbft_message::{PbftBlock, PbftMessage, PbftMessageInfo, PbftViewChange};
+use protos::pbft_message::{PbftBlock, PbftMessage, PbftMessageInfo, PbftNetworkChange, PbftViewChange};
 
 // All message types that have "info" inside of them
 pub trait PbftGetInfo<'a> {
@@ -44,6 +44,7 @@ impl<'a> PbftGetInfo<'a> for &'a PbftViewChange {
 
 impl Eq for PbftMessage {}
 impl Eq for PbftViewChange {}
+impl Eq for PbftNetworkChange {}
 
 impl Hash for PbftMessageInfo {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -58,8 +59,9 @@ impl Hash for PbftBlock {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.get_block_id().hash(state);
         self.get_block_num().hash(state);
-        self.get_summary().hash(state);
         self.get_signer_id().hash(state);
+        self.get_previous_id().hash(state);
+        self.get_summary().hash(state);
     }
 }
 
@@ -77,5 +79,13 @@ impl Hash for PbftViewChange {
             msg.get_info().hash(state);
             msg.get_block().hash(state);
         }
+    }
+}
+
+impl Hash for PbftNetworkChange {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.get_peers().hash(state);
+        self.get_head().hash(state);
+        self.get_tentative().hash(state);
     }
 }

--- a/src/message_extensions.rs
+++ b/src/message_extensions.rs
@@ -42,6 +42,12 @@ impl<'a> PbftGetInfo<'a> for &'a PbftViewChange {
     }
 }
 
+impl<'a> PbftGetInfo<'a> for &'a PbftNetworkChange {
+    fn get_msg_info(&self) -> &'a PbftMessageInfo {
+        self.get_info()
+    }
+}
+
 impl Eq for PbftMessage {}
 impl Eq for PbftViewChange {}
 impl Eq for PbftNetworkChange {}
@@ -87,5 +93,6 @@ impl Hash for PbftNetworkChange {
         self.get_peers().hash(state);
         self.get_head().hash(state);
         self.get_tentative().hash(state);
+        self.get_signer_id().hash(state);
     }
 }

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -242,14 +242,20 @@ impl PbftLog {
         self.network_changes.insert(msg);
     }
 
-    pub fn get_network_changes(&mut self, msg: &PbftNetworkChange) -> Vec<&PbftNetworkChange> {
+    pub fn get_network_changes(&self, msg: &PbftNetworkChange) -> Vec<&PbftNetworkChange> {
         self.network_changes
             .iter()
             .filter(|&nc| network_changes_match(msg, nc))
             .collect()
     }
 
-    /// Add a generic PBFT message to the log
+    /// Clear all previous, out of date network change messages we've received. This can be done
+    /// after one has been accepted (2f + 1 matching received).
+    pub fn clear_network_changes(&mut self) {
+        self.network_changes.clear();
+    }
+
+    // Methods for dealing with PbftMessages
     pub fn add_message(&mut self, msg: PbftMessage) {
         if msg.get_info().get_seq_num() < self.high_water_mark
             || msg.get_info().get_seq_num() >= self.low_water_mark

--- a/src/message_type.rs
+++ b/src/message_type.rs
@@ -44,6 +44,7 @@ pub enum PbftMessageType {
     BlockNew,
     Checkpoint,
     ViewChange,
+    NetworkChange,
 
     Unset,
 }
@@ -57,6 +58,7 @@ impl fmt::Display for PbftMessageType {
             PbftMessageType::BlockNew => "BN",
             PbftMessageType::Checkpoint => "CP",
             PbftMessageType::ViewChange => "VC",
+            PbftMessageType::NetworkChange => "NC",
             PbftMessageType::Unset => "Un",
         };
         write!(f, "{}", txt)
@@ -84,6 +86,7 @@ impl<'a> From<&'a str> for PbftMessageType {
             "BlockNew" => PbftMessageType::BlockNew,
             "ViewChange" => PbftMessageType::ViewChange,
             "Checkpoint" => PbftMessageType::Checkpoint,
+            "NetworkChange" => PbftMessageType::NetworkChange,
             _ => {
                 warn!("Unhandled PBFT message type: {}", s);
                 PbftMessageType::Unset

--- a/tests/test_liveness.yaml
+++ b/tests/test_liveness.yaml
@@ -71,7 +71,7 @@ services:
           sawtooth.consensus.pbft.peers=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
           sawtooth.consensus.pbft.block_duration=100 \
           sawtooth.consensus.pbft.checkpoint_period=10 \
-          sawtooth.consensus.pbft.view_change_timeout=4000 \
+          sawtooth.consensus.pbft.view_change_timeout=30 \
           sawtooth.consensus.pbft.message_timeout=10 \
           sawtooth.consensus.pbft.max_log_size=1000 \
           -o config.batch && \
@@ -84,8 +84,7 @@ services:
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \
             --bind consensus:tcp://eth0:5050 \
-            --peering static \
-            --peers tcp://validator-1:8800,tcp://validator-2:8800,tcp://validator-3:8800
+            --peering dynamic \
             --scheduler parallel \
     \""
     stop_signal: SIGKILL
@@ -108,8 +107,8 @@ services:
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \
             --bind consensus:tcp://eth0:5050 \
-            --peering static \
-            --peers tcp://validator-0:8800,tcp://validator-2:8800,tcp://validator-3:8800
+            --peering dynamic \
+            --seeds tcp://validator-0:8800 \
             --scheduler parallel \
     \""
     stop_signal: SIGKILL
@@ -132,8 +131,8 @@ services:
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \
             --bind consensus:tcp://eth0:5050 \
-            --peering static \
-            --peers tcp://validator-0:8800,tcp://validator-1:8800,tcp://validator-3:8800
+            --peering dynamic \
+            --seeds tcp://validator-0:8800 \
             --scheduler parallel \
     \""
     stop_signal: SIGKILL
@@ -156,8 +155,8 @@ services:
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \
             --bind consensus:tcp://eth0:5050 \
-            --peering static \
-            --peers tcp://validator-0:8800,tcp://validator-1:8800,tcp://validator-2:8800
+            --peering dynamic \
+            --seeds tcp://validator-0:8800 \
             --scheduler parallel \
     \""
     stop_signal: SIGKILL


### PR DESCRIPTION
This is an incomplete implementation of dynamic networking for PBFT, going into the long-lived branch dynamic-networking.

Presently, the validator does not give enough information to the PBFT engine to support consensus on fully dynamic networking. In this implementation, peers can be dynamically added to the network. However, the validator does not ever tell the consensus engine when a peer disconnects, so it is currently not possible to perform consensus on the removal of a peer.

