### PR TITLE
Allow unknown lints

### DIFF
--- a/src/message_extensions.rs
+++ b/src/message_extensions.rs
@@ -19,7 +19,7 @@
 
 // We know that the property `k1 == k2 ==>  hash(k1) == hash(k2)` holds, since protobuf just compares
 // every field in the struct and that's exactly what the implementation of Hash is doing below
-#![allow(derive_hash_xor_eq)]
+#![allow(unknown_lints, derive_hash_xor_eq)]
 
 use std::hash::{Hash, Hasher};
 


### PR DESCRIPTION
Cargo doesn't recognize clippy lints as valid, so we tell Cargo to ignore lints it doesn't know about.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>