### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @vaporos @agunde406 @bridger-herman @aludvik @jsmitchell @ltseeley


### PR DESCRIPTION
This will automatically add a default set of reviewers to each PR that's opened by non-maintainers.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>