### PR TITLE
Fix Rust formatting

### DIFF
--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -60,7 +60,7 @@ pub struct PbftLog {
     /// How many cycles in between checkpoints
     checkpoint_period: u64,
 
-    /// Backlog of messages (from peers) 
+    /// Backlog of messages (from peers)
     backlog: VecDeque<PeerMessage>,
 
     /// Backlog of blocks (from BlockNews messages)


### PR DESCRIPTION
Aligns formatting with `cargo +stable fmt`

Signed-off-by: Kenneth Koski <knkski@bitwise.io>