### PR TITLE
Update build.rs files to use Customize::default()

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -36,9 +36,7 @@ fn main() {
         out_dir: &dest_path.to_str().unwrap(),
         input: &[proto_path.join("pbft_message.proto").to_str().unwrap()],
         includes: &[proto_path.to_str().unwrap()],
-        customize: Customize {
-            ..Default::default()
-        },
+        customize: Customize::default(),
     }).expect("Protoc Error");
 
     // Create mod.rs accordingly


### PR DESCRIPTION
Protobuf updated and removed Default::default() and
instead we need to use Customize::default()

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>