### PR TITLE
Refactor long functions into smaller, descriptive functions 

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -154,9 +154,21 @@ fn merge_setting_if_set<T: ::std::str::FromStr>(
     setting_field: &mut T,
     setting_key: &str,
 ) {
+    merge_setting_if_set_and_map(settings_map, setting_field, setting_key, |setting| setting)
+}
+
+fn merge_setting_if_set_and_map<U, F, T>(
+    settings_map: &HashMap<String, String>,
+    setting_field: &mut U,
+    setting_key: &str,
+    map: F,
+) where
+    F: Fn(T) -> U,
+    T: ::std::str::FromStr,
+{
     if let Some(setting) = settings_map.get(setting_key) {
         if let Ok(setting_value) = setting.parse() {
-            *setting_field = setting_value;
+            *setting_field = map(setting_value);
         }
     }
 }
@@ -166,11 +178,12 @@ fn merge_millis_setting_if_set(
     setting_field: &mut Duration,
     setting_key: &str,
 ) {
-    if let Some(setting) = settings_map.get(setting_key) {
-        if let Ok(setting_value) = setting.parse() {
-            *setting_field = Duration::from_millis(setting_value);
-        }
-    }
+    merge_setting_if_set_and_map(
+        settings_map,
+        setting_field,
+        setting_key,
+        Duration::from_millis,
+    )
 }
 
 /// Create a mock configuration, given a number of nodes. PeerIds are generated using a Sha256

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,7 +83,7 @@ impl PbftConfig {
 pub fn load_pbft_config(block_id: BlockId, service: &mut Service) -> PbftConfig {
     let mut config = PbftConfig::default();
 
-    let sawtooth_settings: HashMap<String, String> = service
+    let settings: HashMap<String, String> = service
         .get_settings(
             block_id,
             vec![
@@ -94,12 +94,11 @@ pub fn load_pbft_config(block_id: BlockId, service: &mut Service) -> PbftConfig 
                 String::from("sawtooth.consensus.pbft.message_timeout"),
                 String::from("sawtooth.consensus.pbft.max_log_size"),
             ],
-        )
-        .expect("Failed to get on-chain settings");
+        ).expect("Failed to get on-chain settings");
 
     // Get the peers associated with this node (including ourselves). Panic if it is not provided;
     // the network cannot function without this setting.
-    let peers_string = sawtooth_settings
+    let peers_string = settings
         .get("sawtooth.consensus.pbft.peers")
         .expect("'sawtooth.consensus.pbft.peers' must be set");
 
@@ -114,21 +113,21 @@ pub fn load_pbft_config(block_id: BlockId, service: &mut Service) -> PbftConfig 
     config.peers = peers;
 
     // Get various durations
-    if let Some(s) = sawtooth_settings.get("sawtooth.consensus.pbft.block_duration") {
-        if let Ok(block_duration) = s.parse() {
-            config.block_duration = Duration::from_millis(block_duration);
-        }
-    }
-    if let Some(s) = sawtooth_settings.get("sawtooth.consensus.pbft.message_timeout") {
-        if let Ok(message_timeout) = s.parse() {
-            config.message_timeout = Duration::from_millis(message_timeout);
-        }
-    }
-    if let Some(s) = sawtooth_settings.get("sawtooth.consensus.pbft.view_change_timeout") {
-        if let Ok(view_change_timeout) = s.parse() {
-            config.view_change_timeout = Duration::from_millis(view_change_timeout);
-        }
-    }
+    merge_millis_setting_if_set(
+        &settings,
+        &mut config.block_duration,
+        "sawtooth.consensus.pbft.block_duration",
+    );
+    merge_millis_setting_if_set(
+        &settings,
+        &mut config.message_timeout,
+        "sawtooth.consensus.pbft.message_timeout",
+    );
+    merge_millis_setting_if_set(
+        &settings,
+        &mut config.view_change_timeout,
+        "sawtooth.consensus.pbft.view_change_timeout",
+    );
 
     // Check to make sure block_duration < view_change_timeout
     if config.block_duration >= config.view_change_timeout {
@@ -136,18 +135,42 @@ pub fn load_pbft_config(block_id: BlockId, service: &mut Service) -> PbftConfig 
     }
 
     // Get various integer constants
-    if let Some(s) = sawtooth_settings.get("sawtooth.consensus.pbft.checkpoint_period") {
-        if let Ok(checkpoint_period) = s.parse() {
-            config.checkpoint_period = checkpoint_period;
-        }
-    }
-    if let Some(s) = sawtooth_settings.get("sawtooth.consensus.pbft.max_log_size") {
-        if let Ok(max_log_size) = s.parse() {
-            config.max_log_size = max_log_size;
-        }
-    }
+    merge_setting_if_set(
+        &settings,
+        &mut config.checkpoint_period,
+        "sawtooth.consensus.pbft.checkpoint_period",
+    );
+    merge_setting_if_set(
+        &settings,
+        &mut config.max_log_size,
+        "sawtooth.consensus.pbft.max_log_size",
+    );
 
     config
+}
+
+fn merge_setting_if_set<T: ::std::str::FromStr>(
+    settings_map: &HashMap<String, String>,
+    setting_field: &mut T,
+    setting_key: &str,
+) {
+    if let Some(setting) = settings_map.get(setting_key) {
+        if let Ok(setting_value) = setting.parse() {
+            *setting_field = setting_value;
+        }
+    }
+}
+
+fn merge_millis_setting_if_set(
+    settings_map: &HashMap<String, String>,
+    setting_field: &mut Duration,
+    setting_key: &str,
+) {
+    if let Some(setting) = settings_map.get(setting_key) {
+        if let Ok(setting_value) = setting.parse() {
+            *setting_field = Duration::from_millis(setting_value);
+        }
+    }
 }
 
 /// Create a mock configuration, given a number of nodes. PeerIds are generated using a Sha256

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -228,9 +228,10 @@ pub fn commit(
 /// to message log for past messages. This usually only makes sense for regular multicast messages
 /// (`PrePrepare`, `Prepare`, and `Commit`)
 pub fn multicast_hint(state: &PbftState, pbft_message: &PbftMessage) -> PbftHint {
-    let msg_type = PbftMessageType::from(pbft_message.get_info().get_msg_type());
+    let msg_info = pbft_message.get_info();
+    let msg_type = PbftMessageType::from(msg_info.get_msg_type());
 
-    if pbft_message.get_info().get_seq_num() > state.seq_num {
+    if msg_info.get_seq_num() > state.seq_num {
         debug!(
             "{}: seq {} > {}, accept all.",
             state,
@@ -238,12 +239,12 @@ pub fn multicast_hint(state: &PbftState, pbft_message: &PbftMessage) -> PbftHint
             state.seq_num
         );
         return PbftHint::FutureMessage;
-    } else if pbft_message.get_info().get_seq_num() == state.seq_num {
+    } else if msg_info.get_seq_num() == state.seq_num {
         if state.working_block.is_none() {
             debug!(
                 "{}: seq {} == {}, in limbo",
                 state,
-                pbft_message.get_info().get_seq_num(),
+                msg_info.get_seq_num(),
                 state.seq_num,
             );
             return PbftHint::PastMessage;
@@ -267,7 +268,7 @@ pub fn multicast_hint(state: &PbftState, pbft_message: &PbftMessage) -> PbftHint
             debug!(
                 "{}: seq {} == {}, in limbo",
                 state,
-                pbft_message.get_info().get_seq_num(),
+                msg_info.get_seq_num(),
                 state.seq_num,
             );
             return PbftHint::PastMessage;
@@ -275,7 +276,7 @@ pub fn multicast_hint(state: &PbftState, pbft_message: &PbftMessage) -> PbftHint
         debug!(
             "{}: seq {} < {}, skip but add to log.",
             state,
-            pbft_message.get_info().get_seq_num(),
+            msg_info.get_seq_num(),
             state.seq_num
         );
         return PbftHint::PastMessage;

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -68,83 +68,118 @@ pub fn pre_prepare(
 ) -> Result<(), PbftError> {
     let info = pbft_message.get_info();
 
+    check_view_mismatch(state, info)?;
+
+    check_pre_prepare_does_not_exist(msg_log, info)?;
+
+    if state.is_primary() {
+        check_pre_prepare_matches_original_block_new(msg_log, pbft_message, info)?;
+    } else {
+        set_seq_num_and_fix_block_new_seq_num(state, msg_log, &pbft_message, info)?;
+    }
+
+    set_current_working_block(state, pbft_message);
+
+    Ok(())
+}
+
+fn check_view_mismatch(state: &PbftState, info: &PbftMessageInfo) -> Result<(), PbftError> {
     if info.get_view() != state.view {
-        return Err(PbftError::ViewMismatch(
+        Err(PbftError::ViewMismatch(
             info.get_view() as usize,
             state.view as usize,
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn check_pre_prepare_does_not_exist(
+    msg_log: &PbftLog,
+    info: &PbftMessageInfo,
+) -> Result<(), PbftError> {
+    // Check that this PrePrepare doesn't already exist
+    let existing_pre_prep_msgs = msg_log.get_messages_of_type(
+        &PbftMessageType::PrePrepare,
+        info.get_seq_num(),
+        info.get_view(),
+    );
+
+    if !existing_pre_prep_msgs.is_empty() {
+        return Err(PbftError::MessageExists(PbftMessageType::PrePrepare));
+    }
+
+    Ok(())
+}
+
+fn check_pre_prepare_matches_original_block_new(
+    msg_log: &PbftLog,
+    pbft_message: &PbftMessage,
+    info: &PbftMessageInfo,
+) -> Result<(), PbftError> {
+    let block_new_msgs = msg_log.get_messages_of_type(
+        &PbftMessageType::BlockNew,
+        info.get_seq_num(),
+        info.get_view(),
+    );
+
+    if block_new_msgs.len() != 1 {
+        return Err(PbftError::WrongNumMessages(
+            PbftMessageType::BlockNew,
+            1,
+            block_new_msgs.len(),
         ));
     }
 
-    // Immutably borrow msg_log for a bit, in a context
-    {
-        // Check that this PrePrepare doesn't already exist
-        let existing_pre_prep_msgs = msg_log.get_messages_of_type(
-            &PbftMessageType::PrePrepare,
-            info.get_seq_num(),
-            info.get_view(),
-        );
-
-        if !existing_pre_prep_msgs.is_empty() {
-            return Err(PbftError::MessageExists(PbftMessageType::PrePrepare));
-        }
+    if block_new_msgs[0].get_block() != pbft_message.get_block() {
+        return Err(PbftError::BlockMismatch(
+            block_new_msgs[0].get_block().clone(),
+            pbft_message.get_block().clone(),
+        ));
     }
-
-    if state.is_primary() {
-        // Check that incoming PrePrepare matches original BlockNew
-        let block_new_msgs = msg_log.get_messages_of_type(
-            &PbftMessageType::BlockNew,
-            info.get_seq_num(),
-            info.get_view(),
-        );
-
-        if block_new_msgs.len() != 1 {
-            return Err(PbftError::WrongNumMessages(
-                PbftMessageType::BlockNew,
-                1,
-                block_new_msgs.len(),
-            ));
-        }
-
-        if block_new_msgs[0].get_block() != pbft_message.get_block() {
-            return Err(PbftError::BlockMismatch(
-                block_new_msgs[0].get_block().clone(),
-                pbft_message.get_block().clone(),
-            ));
-        }
-    } else {
-        // Set this secondary's sequence number from the PrePrepare message
-        // (this was originally set by the primary)...
-        state.seq_num = info.get_seq_num();
-
-        // ...then update the BlockNew message we received with the correct
-        // sequence number
-        let num_updated = msg_log.fix_seq_nums(
-            &PbftMessageType::BlockNew,
-            info.get_seq_num(),
-            info.get_view(),
-            pbft_message.get_block(),
-        );
-
-        debug!(
-            "{}: The log updated {} BlockNew messages to seq num {}",
-            state,
-            num_updated,
-            info.get_seq_num()
-        );
-
-        if num_updated < 1 {
-            return Err(PbftError::WrongNumMessages(
-                PbftMessageType::BlockNew,
-                1,
-                num_updated,
-            ));
-        }
-    }
-
-    // Take the working block from PrePrepare message as our current working block
-    state.working_block = WorkingBlockOption::WorkingBlock(pbft_message.get_block().clone());
 
     Ok(())
+}
+
+fn set_seq_num_and_fix_block_new_seq_num(
+    state: &mut PbftState,
+    msg_log: &mut PbftLog,
+    pbft_message: &PbftMessage,
+    info: &PbftMessageInfo,
+) -> Result<(), PbftError> {
+    // Set this secondary's sequence number from the PrePrepare message
+    // (this was originally set by the primary)...
+    state.seq_num = info.get_seq_num();
+
+    // ...then update the BlockNew message we received with the correct
+    // sequence number
+    let num_updated = msg_log.fix_seq_nums(
+        &PbftMessageType::BlockNew,
+        info.get_seq_num(),
+        info.get_view(),
+        pbft_message.get_block(),
+    );
+
+    debug!(
+        "{}: The log updated {} BlockNew messages to seq num {}",
+        state,
+        num_updated,
+        info.get_seq_num()
+    );
+
+    if num_updated < 1 {
+        Err(PbftError::WrongNumMessages(
+            PbftMessageType::BlockNew,
+            1,
+            num_updated,
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn set_current_working_block(state: &mut PbftState, pbft_message: &PbftMessage) {
+    state.working_block = WorkingBlockOption::WorkingBlock(pbft_message.get_block().clone());
 }
 
 /// Handle a `Commit` message
@@ -158,14 +193,47 @@ pub fn commit(
     pbft_message: &PbftMessage,
     msg_content: Vec<u8>,
 ) -> Result<(), PbftError> {
-    let working_block = if let WorkingBlockOption::WorkingBlock(ref wb) = state.working_block {
-        Ok(wb.clone())
-    } else {
-        Err(PbftError::NoWorkingBlock)
-    }?;
+    let working_block = clone_working_block(state)?;
 
     state.switch_phase(PbftPhase::Finished);
 
+    check_if_block_already_seen(state, &working_block, pbft_message)?;
+
+    check_if_commiting_with_current_chain_head(
+        state,
+        msg_log,
+        service,
+        pbft_message,
+        msg_content,
+        &working_block,
+    )?;
+
+    info!(
+        "{}: Committing block {:?}",
+        state,
+        BlockId::from(pbft_message.get_block().block_id.clone())
+    );
+
+    commit_block_from_message(service, pbft_message)?;
+
+    reset_working_block(state);
+
+    Ok(())
+}
+
+fn clone_working_block(state: &PbftState) -> Result<PbftBlock, PbftError> {
+    if let WorkingBlockOption::WorkingBlock(ref wb) = state.working_block {
+        Ok(wb.clone())
+    } else {
+        Err(PbftError::NoWorkingBlock)
+    }
+}
+
+fn check_if_block_already_seen(
+    state: &PbftState,
+    working_block: &PbftBlock,
+    pbft_message: &PbftMessage,
+) -> Result<(), PbftError> {
     // Don't commit if we've seen this block already, but go ahead if we somehow
     // skipped a block.
     if pbft_message.get_block().get_block_id() != working_block.get_block_id()
@@ -176,13 +244,23 @@ pub fn commit(
             state,
             BlockId::from(pbft_message.get_block().block_id.clone())
         );
-        return Err(PbftError::BlockMismatch(
+        Err(PbftError::BlockMismatch(
             pbft_message.get_block().clone(),
             working_block.clone(),
-        ));
+        ))
+    } else {
+        Ok(())
     }
+}
 
-    // Also make sure that we're committing on top of the current chain head
+fn check_if_commiting_with_current_chain_head(
+    state: &mut PbftState,
+    msg_log: &mut PbftLog,
+    service: &mut Service,
+    pbft_message: &PbftMessage,
+    msg_content: Vec<u8>,
+    working_block: &PbftBlock,
+) -> Result<(), PbftError> {
     let head = service
         .get_chain_head()
         .map_err(|e| PbftError::InternalError(e.description().to_string()))?;
@@ -201,25 +279,26 @@ pub fn commit(
             content: msg_content,
         };
         msg_log.push_backlog(msg);
-        return Err(PbftError::BlockMismatch(
+        Err(PbftError::BlockMismatch(
             pbft_message.get_block().clone(),
             working_block.clone(),
-        ));
+        ))
+    } else {
+        Ok(())
     }
+}
 
-    info!(
-        "{}: Committing block {:?}",
-        state,
-        BlockId::from(pbft_message.get_block().block_id.clone())
-    );
-
+fn commit_block_from_message(
+    service: &mut Service,
+    pbft_message: &PbftMessage,
+) -> Result<(), PbftError> {
     service
         .commit_block(BlockId::from(pbft_message.get_block().block_id.clone()))
-        .map_err(|_| PbftError::InternalError(String::from("Failed to commit block")))?;
+        .map_err(|_| PbftError::InternalError(String::from("Failed to commit block")))
+}
 
-    // Previous block is sent to the validator; reset the working block
+fn reset_working_block(state: &mut PbftState) {
     state.working_block = WorkingBlockOption::NoWorkingBlock;
-    Ok(())
 }
 
 /// Decide if this message is a future message, past message, or current message.
@@ -294,43 +373,72 @@ pub fn view_change(
     service: &mut Service,
     vc_message: &PbftViewChange,
 ) -> Result<(), PbftError> {
-    msg_log.check_msg_against_log(&vc_message, true, 2 * state.f + 1)?;
+    check_received_enough_view_changes(state, msg_log, vc_message)?;
 
-    // Update current view and stop timeout
-    state.view = vc_message.get_info().get_view();
-    warn!("{}: Updating to view {}", state, state.view);
+    set_current_view(state, vc_message);
 
     // Upgrade this node to primary, if its ID is correct
-    if state.get_own_peer_id() == state.get_primary_peer_id() {
-        state.upgrade_role();
-        warn!("{}: I'm now a primary", state);
-
-        // If we're the new primary, need to clean up the block mess from the view change and
-        // initialize a new block.
-        if let WorkingBlockOption::WorkingBlock(ref working_block) = state.working_block {
-            info!(
-                "{}: Ignoring block {}",
-                state,
-                &hex::encode(working_block.get_block_id())
-            );
-            service
-                .ignore_block(BlockId::from(working_block.get_block_id().to_vec()))
-                .unwrap_or_else(|e| error!("Couldn't ignore block: {}", e));
-        } else if let WorkingBlockOption::TentativeWorkingBlock(ref block_id) = state.working_block
-        {
-            info!("{}: Ignoring block {}", state, &hex::encode(block_id));
-            service
-                .ignore_block(block_id.clone())
-                .unwrap_or_else(|e| error!("Couldn't ignore block: {}", e));
-        }
-        info!("{}: Initializing block", state);
-        service
-            .initialize_block(None)
-            .unwrap_or_else(|err| error!("Couldn't initialize block: {}", err));
+    if check_is_primary(state) {
+        become_primary(state, service)
     } else {
-        warn!("{}: I'm now a secondary", state);
-        state.downgrade_role();
+        become_secondary(state)
     }
+
+    set_normal_mode(state);
+
+    Ok(())
+}
+
+fn check_received_enough_view_changes(
+    state: &PbftState,
+    msg_log: &PbftLog,
+    vc_message: &PbftViewChange,
+) -> Result<(), PbftError> {
+    msg_log.check_msg_against_log(&vc_message, true, 2 * state.f + 1)
+}
+
+fn set_current_view(state: &mut PbftState, vc_message: &PbftViewChange) {
+    state.view = vc_message.get_info().get_view();
+    warn!("{}: Updating to view {}", state, state.view);
+}
+
+fn check_is_primary(state: &PbftState) -> bool {
+    state.get_own_peer_id() == state.get_primary_peer_id()
+}
+
+fn become_primary(state: &mut PbftState, service: &mut Service) {
+    state.upgrade_role();
+    warn!("{}: I'm now a primary", state);
+
+    // If we're the new primary, need to clean up the block mess from the view change and
+    // initialize a new block.
+    if let WorkingBlockOption::WorkingBlock(ref working_block) = state.working_block {
+        info!(
+            "{}: Ignoring block {}",
+            state,
+            &hex::encode(working_block.get_block_id())
+        );
+        service
+            .ignore_block(BlockId::from(working_block.get_block_id().to_vec()))
+            .unwrap_or_else(|e| error!("Couldn't ignore block: {}", e));
+    } else if let WorkingBlockOption::TentativeWorkingBlock(ref block_id) = state.working_block {
+        info!("{}: Ignoring block {}", state, &hex::encode(block_id));
+        service
+            .ignore_block(block_id.clone())
+            .unwrap_or_else(|e| error!("Couldn't ignore block: {}", e));
+    }
+    info!("{}: Initializing block", state);
+    service
+        .initialize_block(None)
+        .unwrap_or_else(|err| error!("Couldn't initialize block: {}", err));
+}
+
+fn become_secondary(state: &mut PbftState) {
+    warn!("{}: I'm now a secondary", state);
+    state.downgrade_role();
+}
+
+fn set_normal_mode(state: &mut PbftState) {
     state.working_block = WorkingBlockOption::NoWorkingBlock;
     state.phase = PbftPhase::NotStarted;
     state.mode = PbftMode::Normal;
@@ -339,7 +447,6 @@ pub fn view_change(
         "{}: Entered normal mode in new view {} and stopped timeout",
         state, state.view
     );
-    Ok(())
 }
 
 // There should only be one block with a matching ID

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,8 +54,7 @@ fn main() {
         (@arg connect: -C --connect +takes_value
          "connection endpoint for validator")
         (@arg verbose: -v --verbose +multiple
-         "increase output verbosity"))
-        .get_matches();
+         "increase output verbosity")).get_matches();
 
     let log_level = match matches.occurrences_of("verbose") {
         0 => log::Level::Warn,

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -82,8 +82,7 @@ impl fmt::Display for PbftLog {
                 self.view_changes
                     .iter()
                     .map(|ref msg| msg.get_info().clone()),
-            )
-            .collect();
+            ).collect();
         let string_infos: Vec<String> = msg_infos
             .iter()
             .map(|info: &PbftMessageInfo| -> String {
@@ -94,8 +93,7 @@ impl fmt::Display for PbftLog {
                     info.get_seq_num(),
                     hex::encode(info.get_signer_id()),
                 )
-            })
-            .collect();
+            }).collect();
 
         write!(
             f,
@@ -271,8 +269,7 @@ impl PbftLog {
                 info.get_msg_type() == String::from(msg_type)
                     && info.get_seq_num() == sequence_number
                     && info.get_view() == view
-            })
-            .collect()
+            }).collect()
     }
 
     /// Obtain message information objects from the log that match a given type, sequence number,
@@ -393,8 +390,7 @@ impl PbftLog {
             .filter(|ref msg| {
                 let seq_num = msg.get_info().get_seq_num();
                 seq_num >= self.get_latest_checkpoint() && seq_num > 0
-            })
-            .cloned()
+            }).cloned()
             .collect();
         self.view_changes = self
             .view_changes
@@ -402,8 +398,7 @@ impl PbftLog {
             .filter(|ref msg| {
                 let seq_num = msg.get_info().get_seq_num();
                 seq_num >= self.get_latest_checkpoint() && seq_num > 0
-            })
-            .cloned()
+            }).cloned()
             .collect();
     }
 

--- a/src/message_log.rs
+++ b/src/message_log.rs
@@ -127,11 +127,11 @@ impl PbftLog {
     ///  + A `PrePrepare` message matching the original message (in the current view)
     ///  + `2f + 1` matching `Prepare` messages from different nodes that match
     ///    `PrePrepare` message above (including its own)
-    pub fn prepared(&self, deser_msg: &PbftMessage, f: u64) -> Result<(), PbftError> {
-        if deser_msg.get_info().get_msg_type() != String::from(&PbftMessageType::Prepare) {
+    pub fn prepared(&self, pbft_message: &PbftMessage, f: u64) -> Result<(), PbftError> {
+        if pbft_message.get_info().get_msg_type() != String::from(&PbftMessageType::Prepare) {
             return Err(PbftError::NotReadyForMessage);
         }
-        let info = deser_msg.get_info();
+        let info = pbft_message.get_info();
         let block_new_msgs = self.get_messages_of_type(
             &PbftMessageType::BlockNew,
             info.get_seq_num(),
@@ -174,7 +174,7 @@ impl PbftLog {
             }
         }
 
-        self.check_msg_against_log(&deser_msg, true, 2 * f + 1)?;
+        self.check_msg_against_log(&pbft_message, true, 2 * f + 1)?;
 
         Ok(())
     }
@@ -183,17 +183,17 @@ impl PbftLog {
     /// `committed` is true if for this node:
     ///   + `prepared` is true
     ///   + This node has accepted `2f + 1` `Commit` messages, including its own
-    pub fn committed(&self, deser_msg: &PbftMessage, f: u64) -> Result<(), PbftError> {
-        if deser_msg.get_info().get_msg_type() != String::from(&PbftMessageType::Commit) {
+    pub fn committed(&self, pbft_message: &PbftMessage, f: u64) -> Result<(), PbftError> {
+        if pbft_message.get_info().get_msg_type() != String::from(&PbftMessageType::Commit) {
             return Err(PbftError::NotReadyForMessage);
         }
-        self.check_msg_against_log(&deser_msg, true, 2 * f + 1)?;
+        self.check_msg_against_log(&pbft_message, true, 2 * f + 1)?;
 
-        let mut prep_msg = deser_msg.clone();
-        let mut info = prep_msg.get_info().clone();
+        let mut prepare_message = pbft_message.clone();
+        let mut info = prepare_message.get_info().clone();
         info.set_msg_type(String::from(&PbftMessageType::Prepare));
-        prep_msg.set_info(info);
-        self.prepared(&prep_msg, f)?;
+        prepare_message.set_info(info);
+        self.prepared(&prepare_message, f)?;
         Ok(())
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -179,8 +179,7 @@ impl PbftNode {
                     self.service
                         .check_blocks(vec![BlockId::from(
                             pbft_message.get_block().clone().block_id,
-                        )])
-                        .map_err(|_| {
+                        )]).map_err(|_| {
                             PbftError::InternalError(String::from("Failed to check blocks"))
                         })?;
                 }
@@ -243,7 +242,10 @@ impl PbftNode {
                         message_type: msg.message_type.clone(),
                         content: msg.content.clone(),
                     });
-                    debug!("{}: Not in NotStarted; not handling checkpoint yet", self.state);
+                    debug!(
+                        "{}: Not in NotStarted; not handling checkpoint yet",
+                        self.state
+                    );
                     return Ok(());
                 }
 
@@ -262,8 +264,11 @@ impl PbftNode {
                 }
 
                 if self.state.mode == PbftMode::Checkpointing {
-                    self.msg_log
-                        .check_msg_against_log(&&pbft_message, true, 2 * self.state.f + 1)?;
+                    self.msg_log.check_msg_against_log(
+                        &&pbft_message,
+                        true,
+                        2 * self.state.f + 1,
+                    )?;
                     warn!(
                         "{}: Reached stable checkpoint (seq num {}); garbage collecting logs",
                         self.state,

--- a/src/node.rs
+++ b/src/node.rs
@@ -77,8 +77,7 @@ impl PbftNode {
     /// `Prepare`, `Commit`, `Checkpoint`, or `ViewChange`. If a node receives a type of message
     /// before it is ready to do so, the message is pushed into a backlog queue.
     pub fn on_peer_message(&mut self, msg: &PeerMessage) -> Result<(), PbftError> {
-        let msg_type = msg.message_type.clone();
-        let msg_type = PbftMessageType::from(msg_type.as_str());
+        let msg_type = PbftMessageType::from(msg.message_type.as_str());
 
         // Handle a multicast protocol message
         let multicast_hint = if msg_type.is_multicast() {


### PR DESCRIPTION
This PR aims to improve readability by refactoring long functions into multiple, smaller, descriptively named functions.

Sorry @knkski I messed up on #20 and accidentally pushed to the bitwiseio fork instead of mine. Had to close that and open this, but I will address your comments here.